### PR TITLE
Normalize Context Values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "phpunit/phpunit": "^6.0 | ^7.0 | ^8.0",
     "psr/container": "^1.0",
     "vimeo/psalm": "^3.11.7 | ^4.0",
-    "slevomat/coding-standard": "^6.0"
+    "slevomat/coding-standard": "^6.0",
+    "symfony/polyfill-php80": "^1.19"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d83edcd0cb01de241cf72271c057569",
+    "content-hash": "94589a2cc8b24180fd9ebaf58fded742",
     "packages": [
         {
             "name": "dhii/output-renderer-interface",


### PR DESCRIPTION
Since the new interface permits `scalar|Stringable` as context value, the following changes have been made to the implementation:

- Scalars other than bool will be cast to string.
- Booleans will be first cast to int, resulting in consistent `1` and `0`.
- Stringable objects will be cast to string.
- All other values result in a `RangeException`.